### PR TITLE
【修正】 adzipスキーマに都道府県のみ市区町村のみの場合の不具合対応

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -60,7 +60,12 @@ module Types
         end
       end
       
-      #上記で抽出できない場合、引数をキーとする
+      #都道府県のみや市区町村のみの引数の場合、エラーメッセージ返す。
+      if separates[1] == ""
+        raise GraphQL::ExecutionError.new('引数に字（あざ）を入力してください。', extensions: {address: "字（あざ）が存在しません。"})
+      end
+      
+      #字（あざ）のみの場合、引数をキーとする
       separates = Array.new(2,address) if separates.blank?
       
       #抽出したキーを部分一致で参照する

--- a/spec/requests/graphqls_spec.rb
+++ b/spec/requests/graphqls_spec.rb
@@ -185,6 +185,42 @@ RSpec.describe Types::QueryType do
         assert_equal (result["errors"][0]["extensions"]["address"]), "該当する住所がございません。"
       end
       
+      it "引数が都道府県のみの場合、nilを返し、エラーメッセージも返す" do
+        query_string = <<-GRAPHQL
+        query($address: String!) {
+          adzip(address: $address) {
+            zipcode
+            address1
+            address2
+            address3
+          }
+        }
+        GRAPHQL
+        variables = { address: "新潟県" }
+        result = AppSchema.execute(query_string, context: {}, variables: variables )
+        assert_nil (result["data"]["adzip"])
+        assert_equal (result["errors"][0]["message"]), "引数に字（あざ）を入力してください。"
+        assert_equal (result["errors"][0]["extensions"]["address"]), "字（あざ）が存在しません。"
+      end
+      
+      it "引数が市区町村のみの場合、nilを返し、エラーメッセージも返す" do
+        query_string = <<-GRAPHQL
+        query($address: String!) {
+          adzip(address: $address) {
+            zipcode
+            address1
+            address2
+            address3
+          }
+        }
+        GRAPHQL
+        variables = { address: "三条市" }
+        result = AppSchema.execute(query_string, context: {}, variables: variables )
+        assert_nil (result["data"]["adzip"])
+        assert_equal (result["errors"][0]["message"]), "引数に字（あざ）を入力してください。"
+        assert_equal (result["errors"][0]["extensions"]["address"]), "字（あざ）が存在しません。"
+      end
+      
       it "住所が字（あざ）のみの場合、正しい郵便番号を返す" do
         query_string = <<-GRAPHQL
         query($address: String!) {


### PR DESCRIPTION
adzipスキーマの引数に都道府県のみや市区町村のみを与えると全件取得する不具合が発生。
ー上記の場合はnilを返し、エラーメッセージを返す仕様へ修正。
ー修正に伴うテストコードも実装。